### PR TITLE
switch from cartopy to contextily (fewer API calls) for fetching basemaps

### DIFF
--- a/opensarlab_lib/aoi_selectors.py
+++ b/opensarlab_lib/aoi_selectors.py
@@ -9,6 +9,8 @@ import matplotlib.patches as patches
 import numpy as np
 import pyproj
 
+plt.rcParams.update({'font.size': 12})
+
 ########################
 #  Subset AOI Selector #
 ########################

--- a/opensarlab_lib/aoi_selectors.py
+++ b/opensarlab_lib/aoi_selectors.py
@@ -1,27 +1,13 @@
 from typing import List, Optional, Union, Tuple
 
 import cartopy.crs
-import cartopy.feature as cfeature
-from cartopy.io.img_tiles import GoogleTiles, OSM
+import contextily as ctx
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.widgets import RectangleSelector
 import matplotlib.patches as patches
 import numpy as np
 import pyproj
-
-plt.rcParams.update({'font.size': 12})
-
-
-class EsriImagery(GoogleTiles):
-    def _image_url(self, tile):
-        x, y, z = tile
-        url = (
-            'https://server.arcgisonline.com/ArcGIS/rest/services/'
-            f'World_Imagery/MapServer/tile/{z}/{y}/{x}'
-        )
-        return url
-
 
 ########################
 #  Subset AOI Selector #
@@ -67,10 +53,7 @@ class AOI_Selector:
 
         self.fig = plt.figure(figsize=figsize)     
 
-        esri_tiler = EsriImagery()
-        osm_tiler = OSM()
-
-        self.ax = self.fig.add_subplot(1, 1, 1, projection=esri_tiler.crs)
+        self.ax = self.fig.add_subplot(1, 1, 1, projection=cartopy.crs.epsg(3857))
 
         x_padding = (self.extents[1] - self.extents[0]) / 10
         y_padding = (self.extents[3] - self.extents[2]) / 10
@@ -85,12 +68,8 @@ class AOI_Selector:
             crs=cartopy.crs.PlateCarree()
         )
 
-        zoom_level = 10
-        self.ax.add_image(esri_tiler, zoom_level)
-        self.ax.add_image(osm_tiler, zoom_level, alpha=0.5)
-        self.ax.add_feature(cfeature.BORDERS)
-        self.ax.add_feature(cfeature.COASTLINE)
- 
+        ctx.add_basemap(self.ax, crs="EPSG:3857", source=ctx.providers.Esri.WorldImagery)
+        ctx.add_basemap(self.ax, crs="EPSG:3857", source=ctx.providers.OpenStreetMap.Mapnik, alpha=0.5)
         gl = self.ax.gridlines(crs=cartopy.crs.PlateCarree(), draw_labels=True,
                                linewidth=1, color='gray', alpha=0.5, linestyle='--')
         gl.top_labels = False

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=[
         "asf_search",
         "cartopy",
+        "contextily",
         "gdal",
         "hyp3_sdk",
         "ipywidgets",


### PR DESCRIPTION
Fixes: https://github.com/ASFOpenSARlab/opensarlab_MintPy_Recipe_Book/issues/26

`cartopy.io.image_tiles` hits the image server a lot, which triggers OSL rate limiting on outgoing traffic and results in incomplete basemaps in the AOI selector when plotting areas large enough to cover a Sentinel frame. Contextily is able to load large basemaps in few enough requests to avoid interference from the rate limiter.

Loading basemaps with `cartopy`:
![image](https://github.com/user-attachments/assets/f96ce580-e64c-403c-bac3-9ec1c76a5d98)

Loading basemaps with `contextily`:
![image](https://github.com/user-attachments/assets/8cf22801-7849-46b1-aa14-d4150456cb80)
